### PR TITLE
Removed comma

### DIFF
--- a/InvertibleScrollView.js
+++ b/InvertibleScrollView.js
@@ -43,7 +43,7 @@ let InvertibleScrollView = createReactClass({
     var {
       inverted,
       renderScrollComponent,
-      ...props,
+      ...props
     } = this.props;
 
     if (inverted) {


### PR DESCRIPTION
Removed comma so that invertibleScrollView works with Babel 7.
Parent of parent fixed issue here: https://github.com/expo/react-native-invertible-scroll-view/commit/e14d833324b2dd19d761a1e616e0b5a9c9eb2544